### PR TITLE
Auto control logic

### DIFF
--- a/ohm_igvc/CMakeLists.txt
+++ b/ohm_igvc/CMakeLists.txt
@@ -144,6 +144,10 @@ include_directories(
 # )
 
 # ADD NEW CPPs HERE
+add_executable(auto_control_logic src/auto_control_logic.cpp)
+add_dependencies(auto_control_logic ${PROJECT_NAME}_generate_messages_cpp)
+target_link_libraries(auto_control_logic ${catkin_LIBRARIES})
+
 add_executable(ohm_pid src/ohm_pid.cpp)
 add_dependencies(ohm_pid ${PROJECT_NAME}_generate_messages_cpp)
 target_link_libraries(ohm_pid ${catkin_LIBRARIES})

--- a/ohm_igvc/launch/start_ohm.launch
+++ b/ohm_igvc/launch/start_ohm.launch
@@ -1,4 +1,7 @@
 <launch>
+	<param name="obstacleOverrideDurationMillis" value="1000.0" />
+	<node pkg="ohm_igvc" type="auto_control_logic" name="auto_control_logic" output="screen"/>
+
 	<node pkg="joy" type="joy_node" name="joy_node" />
 	<node pkg="isc_shared" type="joystick" name="joystick"/>
 	<node pkg="isc_shared" type="manual_control" name="manual_control" output="screen"/>

--- a/ohm_igvc/src/auto_control_logic.cpp
+++ b/ohm_igvc/src/auto_control_logic.cpp
@@ -1,0 +1,44 @@
+#include "ros/ros.h"
+#include "geometry_msgs/Twist.h"
+
+#include <chrono>
+#include <string>
+
+typedef std::chrono::high_resolution_clock Clock;
+typedef std::chrono::milliseconds milliseconds;
+
+ros::Publisher autoPub;
+Clock::time_point lastOverride = Clock::now();
+double overrideDuration
+
+void pidCallback(const geometry_msgs::Twist::ConstPtr& msg){
+    if(std::chrono::duration_cast<milliseconds>(Clock::now() - lastOverride).count() > overrideDuration){
+        autoPub.publish(*msg);
+
+        ROS_INFO("Auto Control: pid linear.x=%f angular.z=%f", msg.linear.x, msg.angular.z);
+    }
+}
+
+void overrideCallback(const geometry_msgs::Twist::ConstPtr& msg){
+    lastOverride = Clock::now();
+	autoPub.publish(*msg);
+
+	ROS_INFO("Auto Control: override linear.x=%f angular.z=%f", msg.linear.x, msg.angular.z);
+}
+
+int main(int argc, char **argv){
+	ros::init(argc, argv, "auto_control_logic");
+
+	ros::NodeHandle n;
+
+    n.param("obstacleOverrideDuration", overrideDuration, 1.0);
+
+	autoPub = n.advertise<geometry_msgs::Twist>("autoControl", 5);
+
+	ros::Subscriber pidSub = n.subscribe("ohmPid", 5, pidCallback);
+    ros::Subscriber overrideSub = n.subscribe("avoidanceOverride", 5, overrideCallback);
+
+	ros::spin();
+	
+	return 0;
+}

--- a/ohm_igvc/src/auto_control_logic.cpp
+++ b/ohm_igvc/src/auto_control_logic.cpp
@@ -1,21 +1,22 @@
 #include "ros/ros.h"
 #include "geometry_msgs/Twist.h"
 
-#include <chrono>
+#include <boost/chrono.hpp>
 #include <string>
 
-typedef std::chrono::high_resolution_clock Clock;
-typedef std::chrono::milliseconds milliseconds;
+//https://stackoverflow.com/a/4974588 but use boost
+typedef boost::chrono::high_resolution_clock Clock;
+typedef boost::chrono::milliseconds milliseconds;
 
 ros::Publisher autoPub;
 Clock::time_point lastOverride = Clock::now();
-double overrideDuration
+double overrideDuration;
 
 void pidCallback(const geometry_msgs::Twist::ConstPtr& msg){
-    if(std::chrono::duration_cast<milliseconds>(Clock::now() - lastOverride).count() > overrideDuration){
+    if(boost::chrono::duration_cast<milliseconds>(Clock::now() - lastOverride).count() > overrideDuration){
         autoPub.publish(*msg);
 
-        ROS_INFO("Auto Control: pid linear.x=%f angular.z=%f", msg.linear.x, msg.angular.z);
+        ROS_INFO("Auto Control: pid linear.x=%f angular.z=%f", msg->linear.x, msg->angular.z);
     }
 }
 
@@ -23,7 +24,7 @@ void overrideCallback(const geometry_msgs::Twist::ConstPtr& msg){
     lastOverride = Clock::now();
 	autoPub.publish(*msg);
 
-	ROS_INFO("Auto Control: override linear.x=%f angular.z=%f", msg.linear.x, msg.angular.z);
+	ROS_INFO("Auto Control: override linear.x=%f angular.z=%f", msg->linear.x, msg->angular.z);
 }
 
 int main(int argc, char **argv){
@@ -31,7 +32,7 @@ int main(int argc, char **argv){
 
 	ros::NodeHandle n;
 
-    n.param("obstacleOverrideDuration", overrideDuration, 1.0);
+    n.param("obstacleOverrideDurationMillis", overrideDuration, 1000.0);
 
 	autoPub = n.advertise<geometry_msgs::Twist>("autoControl", 5);
 


### PR DESCRIPTION
Closes #14
Works correctly when simulating messages. 

Listens for messages from #17 on `/avoidanceOverride` and forwards them on to `/autoControl` while blocking PID messages for a brief time.
Listens for messages from #18 on `/ohmPid` and forwards them on to `/autoControl` if not blocked.

Uses ROS param `obstacleOverrideDurationMillis`, which is the amount of time in milliseconds that `/ohmPid` messages will be blocked after receiving an `/avoidanceOverride` message. Defaults to 1000.0, or 1 second.